### PR TITLE
Fix: Return correct control when not using `first_in_center`

### DIFF
--- a/addons/advanced_radial_menu/radial_menu_class.gd
+++ b/addons/advanced_radial_menu/radial_menu_class.gd
@@ -132,7 +132,17 @@ func force_update() -> void:
 	_update_children()
 
 func get_selected_child() -> Node:
-	return get_child(_current_selection_idx + (1 if first_in_center else -1))
+	if _current_selection_idx == -1:
+		if first_in_center and _children_list.size() > 0:
+			return _children_list[0]
+
+		return null
+
+	var child_idx := _current_selection_idx + (1 if first_in_center else 0)
+	if child_idx >= 0 and child_idx < _children_list.size():
+		return _children_list[child_idx]
+
+	return null
 
 func select() -> void: # select currently hovered element. Like trigerring action "select_action_name"
 	if (_current_selection_idx == -2):


### PR DESCRIPTION
The `get_selected_child` function in `radial_menu_class.gd` (and by proxy the `slot_selected` signal) returns the wrong `Control` when not using the `first_in_center` mode.

If `first_in_center` is true, everything returns correctly, but when set to `false`, it will return the item _after_ the selected one.

This can be seen in the example scene included with the plugin. If changing the example to disable `first_in_center`, selecting a slot instead highlights the next one, rather than the selected one, as can be seen in the screenshot below:

<img width="604" height="479" alt="image" src="https://github.com/user-attachments/assets/46bf2308-fd4c-4021-bc70-79137dff8c43" />

The change in this pull request will ensure that the correct `Control` is returned both with and without `first_in_center` mode.