### PR TITLE
Fix: Ensure section lines are drawn last

### DIFF
--- a/addons/advanced_radial_menu/radial_menu_class.gd
+++ b/addons/advanced_radial_menu/radial_menu_class.gd
@@ -231,6 +231,22 @@ func _draw_child(i: int, radial_position_offset := Vector2.ZERO) -> void:
 			child.rotation_degrees = 360 - (360 * int(i / float(_local_children_count)))
 
 
+func _draw_section_lines() -> void:
+	if _local_children_count <= 1:
+		return
+
+	for i: int in _local_children_count:
+		var angle := i * (TAU / _local_children_count) - CONSTANT_ANGLE_OFFSET
+		angle += deg_to_rad(_line_rotation_offset)
+
+		var point := Vector2.from_angle(angle)
+		draw_line(
+			_current_menu_offset + point * arc_inner_radius,
+			_current_menu_offset + point * _current_menu_radius,
+			line_color,
+			line_width,
+			line_antialised
+		)
 
 
 func _draw() -> void:
@@ -305,16 +321,6 @@ func _draw() -> void:
 					)
 			
 			
-			if _local_children_count > 1:
-				var point := Vector2.from_angle(angle)
-				draw_line(
-					_current_menu_offset +  point * arc_inner_radius,
-					_current_menu_offset +  point * _current_menu_radius,
-					line_color,
-					line_width,
-					line_antialised
-				)
-			
 			if first_in_center:
 				i += 1
 			
@@ -334,6 +340,8 @@ func _draw() -> void:
 		if _time_tick >= 100.0:
 			_time_tick = 0.0
 		draw_arc(_current_menu_offset, (_current_menu_radius - animated_pulse_offset + animated_pulse_intensity + sin(_time_tick * animated_pulse_speed) * animated_pulse_intensity), TAU, 128, arc_detail, animated_pulse_color, arc_line_width, arc_antialiased)
+
+	_draw_section_lines()
 
 
 


### PR DESCRIPTION
In the current code, the section lines are drawn in the same loop as the background / hover colours. This introduces a problem that is more noticeable when using fully opaque hover colours - that being the hover colours can and do get drawn over the top of the section lines.

This change changes the draw order to do a final pass at the end of `_draw` to ensure the section lines are drawn over the top of everything else which ensures the line thickness remains consistent.